### PR TITLE
fix(hawk): never use RemoteAddr for host/port

### DIFF
--- a/hawk.go
+++ b/hawk.go
@@ -249,15 +249,6 @@ func extractReqHostPort(req *http.Request) (host string, port string) {
 	} else {
 		host = req.Host
 	}
-	if req.RemoteAddr != "" && (host == "" || port == "") {
-		addrHost, addrPort, _ := net.SplitHostPort(req.RemoteAddr)
-		if host == "" {
-			host = addrHost
-		}
-		if port == "" {
-			port = addrPort
-		}
-	}
 	if req.URL.Host != "" {
 		if idx := strings.Index(req.Host, ":"); idx != -1 {
 			host, port, _ = net.SplitHostPort(req.Host)


### PR DESCRIPTION
I encountered a problem where the MAC was failing because the server was
using the RemoteAddr port in the normalized string and the client was
using the servers.

I don't understand when using RemoteAddr would ever make sense here.
