### PR TITLE
being more defensive about how we put together the URI value before hash...

### DIFF
--- a/hawk.go
+++ b/hawk.go
@@ -224,7 +224,10 @@ func NewAuthFromRequest(req *http.Request, creds CredentialsLookupFunc, nonce No
 	}
 
 	auth.Method = req.Method
-	auth.RequestURI = req.RequestURI
+	auth.RequestURI = req.URL.Path
+	if req.URL.RawQuery != "" {
+		auth.RequestURI += "?" + req.URL.RawQuery
+	}
 	if bewit != "" {
 		auth.Method = "GET"
 		bewitPattern, _ := regexp.Compile(`\?bewit=` + bewit + `\z|bewit=` + bewit + `&|&bewit=` + bewit + `\z`)


### PR DESCRIPTION
...ing

Due to ambiguity in the HTTP RFC (http://www.w3.org/Protocols/rfc2616/rfc2616.txt) individual package developers are at liberty to determine whether req.RequestURI contains just the path?plus=args or the http://full.request/with/path?plus=args and some golang http wrappers make one choice while others make the other choice.

Closes #4.
