### PR TITLE
Use lexer to parse hawk headers for 20x performance improvement

### DIFF
--- a/hawk.go
+++ b/hawk.go
@@ -370,8 +370,7 @@ func lexField(r *strings.Reader) (string, string, error) {
 		}
 		key = append(key, ch)
 	}
-	ch, _ := r.ReadByte()
-	if ch != '"' {
+	if ch, _ := r.ReadByte(); ch != '"' {
 		return "", "", AuthFormatError{string(key), "cannot parse value"}
 	}
 	// read the value
@@ -390,7 +389,7 @@ func lexField(r *strings.Reader) (string, string, error) {
 	return string(key), string(val), nil
 }
 
-func LexHeader(header string) (map[string]string, error) {
+func lexHeader(header string) (map[string]string, error) {
 	params := make(map[string]string, 8)
 
 	r := strings.NewReader(header)
@@ -426,7 +425,7 @@ func (auth *Auth) ParseHeader(header string, t AuthType) error {
 		return AuthFormatError{"scheme", "must be Hawk"}
 	}
 
-	fields, err := LexHeader(header[4:])
+	fields, err := lexHeader(header[4:])
 	if err != nil {
 		return err
 	}

--- a/hawk_test.go
+++ b/hawk_test.go
@@ -278,6 +278,6 @@ func BenchmarkRegexParser(b *testing.B) {
 
 func BenchmarkLexingParser(b *testing.B) {
 	for i := 0; i < b.N; i++ {
-		LexHeader(header[4:])
+		lexHeader(header[4:])
 	}
 }


### PR DESCRIPTION
This is a lexing version of the header parsing performance changes suggested by dmiles here: https://github.com/tent/hawk-go/pull/5

It's a fair amount of code but provides a significant performance improvement.

Here are the benchmark results for parsing the header with the lexer rather than regexp:
BenchmarkRegexParser       50000         67204 ns/op
BenchmarkLexingParser     500000          3335 ns/op
