### PR TITLE
Ignore URL.Opaque when signing requests

### DIFF
--- a/hawk.go
+++ b/hawk.go
@@ -224,10 +224,7 @@ func NewAuthFromRequest(req *http.Request, creds CredentialsLookupFunc, nonce No
 	}
 
 	auth.Method = req.Method
-	auth.RequestURI = req.URL.Path
-	if req.URL.RawQuery != "" {
-		auth.RequestURI += "?" + req.URL.RawQuery
-	}
+	auth.RequestURI = extractRequestURI(req)
 	if bewit != "" {
 		auth.Method = "GET"
 		bewitPattern, _ := regexp.Compile(`\?bewit=` + bewit + `\z|bewit=` + bewit + `&|&bewit=` + bewit + `\z`)
@@ -269,6 +266,14 @@ func extractReqHostPort(req *http.Request) (host string, port string) {
 	return
 }
 
+func extractRequestURI(req *http.Request) string {
+	uri := req.URL.Path
+	if req.URL.RawQuery != "" {
+		uri += "?" + req.URL.RawQuery
+	}
+	return uri
+}
+
 // NewRequestAuth builds a client Auth based on req and creds. tsOffset will be
 // applied to Now when setting the timestamp.
 func NewRequestAuth(req *http.Request, creds *Credentials, tsOffset time.Duration) *Auth {
@@ -277,7 +282,7 @@ func NewRequestAuth(req *http.Request, creds *Credentials, tsOffset time.Duratio
 		Credentials: *creds,
 		Timestamp:   Now().Add(tsOffset),
 		Nonce:       nonce(),
-		RequestURI:  req.URL.RequestURI(),
+		RequestURI:  extractRequestURI(req),
 	}
 	auth.Host, auth.Port = extractReqHostPort(req)
 	return auth

--- a/hawk_test.go
+++ b/hawk_test.go
@@ -171,8 +171,7 @@ func (s *HawkSuite) TestRequestAuth(c *C) {
 	}
 }
 
-func (s *HawkSuite) TestRequestSigning(c *C) {
-	u, _ := url.Parse("https://example.net/somewhere/over/the/rainbow")
+func testRequestSigning(u *url.URL, c *C) {
 	auth := NewRequestAuth(&http.Request{URL: u, Method: "POST"},
 		&Credentials{ID: "123456", Key: "2983d45yun89q", Hash: sha256.New}, 0)
 	auth.Nonce = "Ygvqdz"
@@ -182,6 +181,18 @@ func (s *HawkSuite) TestRequestSigning(c *C) {
 	h.Write([]byte("something to write about"))
 	auth.SetHash(h)
 	c.Assert(auth.RequestHeader(), Equals, `Hawk id="123456", mac="q1CwFoSHzPZSkbIvl0oYlD+91rBUEvFk763nMjMndj8=", ts="1353809207", nonce="Ygvqdz", hash="2QfCt3GuY9HQnHWyWD3wX68ZOKbynqlfYmuO2ZBRqtY=", ext="Bazinga!"`)
+}
+
+func (s *HawkSuite) TestRequestSigning(c *C) {
+	u, _ := url.Parse("https://example.net/somewhere/over/the/rainbow")
+	testRequestSigning(u, c)
+}
+
+func (s *HawkSuite) TestRequestSigningWithOpaque(c *C) {
+	uri := "https://example.net/somewhere/over/the/rainbow"
+	u, _ := url.Parse(uri)
+	u.Opaque = uri
+	testRequestSigning(u, c)
 }
 
 var responseAuthHeaderTests = []struct {


### PR DESCRIPTION
This makes it so we use the same logic to create the RequestURI from the client and server side.
