### PR TITLE
Set a nonce in *Auth returned in func NewURLAuth(...)

### DIFF
--- a/hawk.go
+++ b/hawk.go
@@ -294,6 +294,7 @@ func NewURLAuth(uri string, creds *Credentials, tsOffset time.Duration) (*Auth, 
 		Method:      "GET",
 		Credentials: *creds,
 		Timestamp:   Now().Add(tsOffset),
+		Nonce:       nonce(),
 	}
 	if u.Path != "" {
 		// url.Parse unescapes the path, which is unexpected


### PR DESCRIPTION
@titanous Note, `NewRequestAuth` is already setting a nonce, but `NewURLAuth` isn't (and I believe it should). This PR fixes this.