### PR TITLE
Revert "Set a nonce in *Auth returned in func NewURLAuth(...)" since

### DIFF
--- a/hawk.go
+++ b/hawk.go
@@ -294,7 +294,6 @@ func NewURLAuth(uri string, creds *Credentials, tsOffset time.Duration) (*Auth, 
 		Method:      "GET",
 		Credentials: *creds,
 		Timestamp:   Now().Add(tsOffset),
-		Nonce:       nonce(),
 	}
 	if u.Path != "" {
 		// url.Parse unescapes the path, which is unexpected


### PR DESCRIPTION
nonce is not used in bewits.

This reverts commit 17ebb94644c1909dd054fc94b58fa5e83bb6859d.

I'm so sorry about this! I actually woke up in the night, and then suddenly realised that this was the reason the nonce wasn't set... So my PR from a few hours ago was invalid.