### PR TITLE
remove explicit check of error message value for stale timestamp

### DIFF
--- a/hawk.go
+++ b/hawk.go
@@ -663,7 +663,6 @@ func (auth *Auth) UpdateOffset(header string) (time.Duration, error) {
 	var err error
 	var ts time.Time
 	var tsm []byte
-	var errMsg string
 
 	for _, match := range matches {
 		switch match[1] {
@@ -678,13 +677,7 @@ func (auth *Auth) UpdateOffset(header string) (time.Duration, error) {
 			if err != nil {
 				return 0, AuthFormatError{"tsm", "malformed base64 encoding"}
 			}
-		case "error":
-			errMsg = match[2]
 		}
-	}
-
-	if errMsg != "Stale timestamp" {
-		return 0, AuthFormatError{"error", "missing or unknown"}
 	}
 
 	if !hmac.Equal(tsm, auth.tsMac(strconv.FormatInt(ts.Unix(), 10))) {


### PR DESCRIPTION
The `UpdateOffset` func fails on server implementations that do not return the exact error message 'Stale timestamp'.

Just for reference, the official Hawk client does not check the error message:
https://github.com/hueniverse/hawk/blob/05e585d4105a07528d8786ca04c90bcbfbcd5757/lib/client.js#L171
